### PR TITLE
Fix: デプロイ時に起きるエラーを対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sauna_linebot",
+  "name": "sauna_no_susume",
   "private": true,
   "dependencies": {
     "@popperjs/core": "^2.11.0",
@@ -11,6 +11,10 @@
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",
+  "engines": {
+    "node": "12.14.0",
+    "npm": "6.13.4"
+  },
   "devDependencies": {
     "webpack-dev-server": "^4.5.0"
   }


### PR DESCRIPTION
## 概要

- `package.json`にNode.jsのバージョンを指定

- エラーの原因の1つは、herokuの`Buildpacks`でした。上からheroku/nodejs→heroku/rubyの順に変更するとデプロイ成功
## 概要
[2021年]herokuでrails + nodejsでnodeのバージョン指定する方法
https://qiita.com/ki-sato/items/d7a41b09ca969d0a7372