### PR TITLE
Improve: 動画をループ再生に設定#30

### DIFF
--- a/app/javascript/packs/videos/show.js
+++ b/app/javascript/packs/videos/show.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const video = document.getElementById('video');
+  const youtube_id = video.dataset.youtube;
+
+  const tag = document.createElement('script');
+  tag.src = "https://www.youtube.com/iframe_api";
+  const firstScriptTag = document.getElementsByTagName('script')[0];
+  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+  let player;
+  window.onYouTubeIframeAPIReady = function() {
+    player = new YT.Player('player', {
+      width: '560',
+      height: '315',
+      videoId: youtube_id,
+      events: {
+        // api呼び出す準備ができると起動
+        'onReady': function(evt) {
+          evt.target.mute();
+          evt.target.playVideo();
+        },
+        // プレーヤーの状態が変わると起動
+        'onStateChange': function(evt) {
+          switch (evt.data) {
+            // 動画をループ再生
+            case YT.PlayerState.ENDED:
+              evt.target.playVideo();
+              break;
+          }
+        }
+      },
+      playerVars: {
+        playsinline: 1,
+      }
+    });
+  }
+})

--- a/app/views/videos/show.html.slim
+++ b/app/views/videos/show.html.slim
@@ -1,8 +1,9 @@
-= content_tag 'iframe', nil, width: 560, height: 315, src: "https://www.youtube-nocookie.com/embed/#{@video.youtube_id}", frameborder: 0, allow: 'encrypted-media', allowfullscreen: true
+= javascript_pack_tag 'videos/show'
+/ show.jsにyoutube_idを読み込みさせている
+#video data-youtube="#{@video.youtube_id}"
+  #player
 br
 = @video.address
 = @video.sauna
 br
 = link_to 'Twitter', "https://twitter.com/share?url=https://sauna-no-susume.herokuapp.com/&text=【#{@video.sauna}】に行ってみたい！&hashtags=サウナ,サウナのすゝめ", target: '_blank', rel: 'noopener noreferrer'
-/ br
-/ = link_to 'LINEで送る', 'https://line.me/R/nv/recommendOA/@353bfsoa', target: '_blank', rel: 'noopener noreferrer'

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,8 @@ module SaunaLinebot
       g.test_framework false
     end
 
+    config.time_zone = 'Asia/Tokyo'
     config.i18n.default_locale = :ja
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
   end
 end


### PR DESCRIPTION
## 概要
直接埋め込んでいたiframeから`youtube player api`を使用し、動画が自動再生・ループ再生されるように設定。
自動再生するためにはミュートが必須なため、今後取り除く可能性あり。

## 参考記事
https://developers.google.com/youtube/iframe_api_reference?hl=ja