### PR TITLE
Add: LINEの友だちをサウナに誘う機能を追加#49

### DIFF
--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -1,7 +1,8 @@
 class VideosController < ApplicationController
-  # skip_before_action :login_required, only: %i[show]
+  skip_before_action :login_required
   before_action :set_search
   before_action :set_liff_id
+  before_action :current_user
 
   def index; end
 

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -1,10 +1,12 @@
 class VideosController < ApplicationController
+  # skip_before_action :login_required, only: %i[show]
   before_action :set_search
+  before_action :set_liff_id
 
   def index; end
 
   def show
     @video = Video.find(params[:id])
-    gon.youtube_id = @video.youtube_id
+    gon.video = @video
   end
 end

--- a/app/javascript/packs/videos/show.js
+++ b/app/javascript/packs/videos/show.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
       // }
     });
   }
-  const redirect_url = `https://liff.line.me/${gon.liff_id}/videos/${gon.video.id}`;
+  const redirect_url = `https://3272-2404-7a80-2c81-7600-bdae-84da-e18d-cd52.ngrok.io/videos/${gon.video.id}`;
   const send = document.getElementById('send');
   send.addEventListener('click', () => {
     // LIFFアプリを初期化。初期化するとSDKのメソッドを実行できる。

--- a/app/javascript/packs/videos/show.js
+++ b/app/javascript/packs/videos/show.js
@@ -21,7 +21,8 @@ document.addEventListener('DOMContentLoaded', () => {
       // }
     });
   }
-  const redirect_url = `https://3272-2404-7a80-2c81-7600-bdae-84da-e18d-cd52.ngrok.io/videos/${gon.video.id}`;
+  const video_url = `https://43f8-180-57-16-113.ngrok.io/videos/${gon.video.id}`;
+  const account_url = `https://lin.ee/YM3TI37`;
   const send = document.getElementById('send');
   send.addEventListener('click', () => {
     // LIFFアプリを初期化。初期化するとSDKのメソッドを実行できる。
@@ -37,27 +38,26 @@ document.addEventListener('DOMContentLoaded', () => {
       liff.shareTargetPicker([
         message = {
           "type": "template",
-          "altText": "サウナのお誘いが届いています",
+          "altText": "サウナのお誘い",
           "template": {
-            "thumbnailImageUrl": "https://res.cloudinary.com/dr1peiwz2/image/upload/v1613642190/girl_ymjnoj.jpg",
+            "thumbnailImageUrl": "https://drive.google.com/uc?export=view&id=1BvbtKEE_7GvHUlusKQnFshFuUPZ2U-Cy",
             "type": "buttons",
-            "title": "サウナのお誘い",
-            "text": "サウナのお誘いが届いています",
+            "title": "サウナのお誘い♨",
+            "text": "サウナに行きたいです！\n一緒にととのいましょう！",
             "actions": [
               {
                 "type": "uri",
                 "label": "誘われたサウナを確認する",
-                "uri": redirect_url
+                "uri": video_url
+              },
+              {
+                "type": "uri",
+                "label": "サウナに行く準備をする",
+                "uri": account_url
               }
             ]
           }
         }
       ])
-      .then(() => {
-        document.getElementById('success').innerText = 'サウナのお誘いをしました'
-      })
-      .catch(() => {
-        document.getElementById('error').innerText = 'サウナのお誘いに失敗しました'
-      });
   })
 })

--- a/app/javascript/packs/videos/show.js
+++ b/app/javascript/packs/videos/show.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const player = new YT.Player('player', {
       width: '560',
       height: '315',
-      videoId: gon.youtube_id,
+      videoId: gon.video.youtube_id,
       playerVars: {
         playsinline: 1,
         rel: 0,
@@ -21,4 +21,43 @@ document.addEventListener('DOMContentLoaded', () => {
       // }
     });
   }
+  const redirect_url = `https://liff.line.me/${gon.liff_id}/videos/${gon.video.id}`;
+  const send = document.getElementById('send');
+  send.addEventListener('click', () => {
+    // LIFFアプリを初期化。初期化するとSDKのメソッドを実行できる。
+    liff.init({
+      liffId: gon.liff_id
+    })
+      .then(() => {
+        if (!liff.isLoggedIn()) {
+          // 開発時、外部ブラウザからアクセスするために利用
+          liff.login()
+        }
+      });
+      liff.shareTargetPicker([
+        message = {
+          "type": "template",
+          "altText": "サウナのお誘いが届いています",
+          "template": {
+            "thumbnailImageUrl": "https://res.cloudinary.com/dr1peiwz2/image/upload/v1613642190/girl_ymjnoj.jpg",
+            "type": "buttons",
+            "title": "サウナのお誘い",
+            "text": "サウナのお誘いが届いています",
+            "actions": [
+              {
+                "type": "uri",
+                "label": "誘われたサウナを確認する",
+                "uri": redirect_url
+              }
+            ]
+          }
+        }
+      ])
+      .then(() => {
+        document.getElementById('success').innerText = 'サウナのお誘いをしました'
+      })
+      .catch(() => {
+        document.getElementById('error').innerText = 'サウナのお誘いに失敗しました'
+      });
+  })
 })

--- a/app/views/videos/show.html.slim
+++ b/app/views/videos/show.html.slim
@@ -12,6 +12,4 @@ br
 br
 = link_to 'Twitter', "https://twitter.com/share?url=https://sauna-no-susume.herokuapp.com/&text=【#{@video.sauna}】に行ってみたい！&hashtags=サウナ,サウナのすゝめ", target: '_blank', rel: 'noopener noreferrer'
 br
-button#send サウナに誘う
-p#success
-p#error
+button#send 友だちをサウナに誘ってみる

--- a/app/views/videos/show.html.slim
+++ b/app/views/videos/show.html.slim
@@ -10,3 +10,7 @@ br
   = render 'watch', { video: @video }
 br
 = link_to 'Twitter', "https://twitter.com/share?url=https://sauna-no-susume.herokuapp.com/&text=【#{@video.sauna}】に行ってみたい！&hashtags=サウナ,サウナのすゝめ", target: '_blank', rel: 'noopener noreferrer'
+br
+button#send サウナに誘う
+p#success
+p#error

--- a/app/views/videos/show.html.slim
+++ b/app/views/videos/show.html.slim
@@ -4,10 +4,11 @@
 br
 = @video.address
 = @video.sauna
-- if @current_user.watch?(@video)
-  = render 'unwatch', { video: @video }
-- else
-  = render 'watch', { video: @video }
+- if @current_user
+  - if @current_user.watch?(@video)
+    = render 'unwatch', { video: @video }
+  - else
+    = render 'watch', { video: @video }
 br
 = link_to 'Twitter', "https://twitter.com/share?url=https://sauna-no-susume.herokuapp.com/&text=【#{@video.sauna}】に行ってみたい！&hashtags=サウナ,サウナのすゝめ", target: '_blank', rel: 'noopener noreferrer'
 br


### PR DESCRIPTION
## 概要
- 動画詳細ページから`liff.shareTargetPicker()`メソッドを実行して、LINEの友だちに添付画像のメッセージでサウナに誘える機能を追加。
- `誘われたサウナを確認する`では外部サーバーから動画詳細ページに遷移。（非ログインでも閲覧可）
- `サウナに行く準備をする`はサウナのすゝめの友だち追加用URLです。
<a href="https://gyazo.com/81445bb7de9db4eedde49a38d9e52934"><img src="https://i.gyazo.com/81445bb7de9db4eedde49a38d9e52934.png" alt="Image from Gyazo" width="263"/></a>