### PR TITLE
Add: 動画タイトルとチャンネル名を詳細ページに表示#46

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :login_required
+  helper_method :current_user
 
   private
 

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -9,5 +9,10 @@ class VideosController < ApplicationController
   def show
     @video = Video.find(params[:id])
     gon.video = @video
+    # Youtube動画のタイトルとチャンネル名を取得
+    oembed_url = URI.parse("https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=#{@video.youtube_id}&format=json")
+    res = Net::HTTP.get_response(oembed_url)
+    @title = JSON.parse(res.body)['title']
+    @author_name = JSON.parse(res.body)['author_name']
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -21,6 +21,6 @@ html
   body
     .container
       .text-center.mintyou
-        - if @current_user
+        - if current_user
           = render 'shared/header'
         = yield

--- a/app/views/videos/_video.html.slim
+++ b/app/views/videos/_video.html.slim
@@ -6,6 +6,7 @@
   = video.sauna
   br
   = video.address
-- if @current_user.watch?(video)
-  span.badge.rounded-pill.bg-primary
-    | 視聴済
+- if current_user
+  - if current_user.watch?(video)
+    span.badge.rounded-pill.bg-primary
+      | 視聴済

--- a/app/views/videos/show.html.slim
+++ b/app/views/videos/show.html.slim
@@ -4,8 +4,12 @@
 br
 = @video.address
 = @video.sauna
-- if @current_user
-  - if @current_user.watch?(@video)
+br
+= @title
+br
+= @author_name
+- if current_user
+  - if current_user.watch?(@video)
     = render 'unwatch', { video: @video }
   - else
     = render 'watch', { video: @video }


### PR DESCRIPTION
## 概要
Youtube動画のメタ情報をoEmbed APIで取得し、取得した情報の動画タイトルとチャンネル名を詳細ページに表示。