### PR TITLE
Fix: いいね動画一覧から検索できるように修正#59

### DIFF
--- a/app/views/shared/_bookmark_header.html.slim
+++ b/app/views/shared/_bookmark_header.html.slim
@@ -2,6 +2,6 @@ header
   nav.navbar.navbar-expand-lg.navbar-light.bg-light.bg-gradient.py-3
     .container
       .row.align-items-center
-        = render 'shared/search_form', url: videos_path
+        = render 'shared/search_form', url: bookmarks_videos_path
       - if current_user
         = render 'shared/drawer'

--- a/app/views/shared/_drawer.html.slim
+++ b/app/views/shared/_drawer.html.slim
@@ -1,0 +1,19 @@
+button.navbar-toggler type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation"
+  span.navbar-toggler-icon
+.collapse.navbar-collapse#navbarNav
+  ul.navbar-nav.text-end
+    li.nav-item.mt-4
+      = link_to profile_path, class: 'nav-link py-0', data: { 'turbolinks': false } do
+        h6
+          i.fa-solid.fa-circle-user.fa-lg
+          | &nbsp;&nbsp;プロフィール
+    li.nav-item.mt-4
+      = link_to videos_path, class: 'nav-link py-0' do
+        h6
+          i.fa-solid.fa-clapperboard.fa-lg
+          | &nbsp;&nbsp;動画一覧
+    li.nav-item.mt-4
+      = link_to bookmarks_videos_path, class: 'nav-link py-0' do
+        h6
+          i.fa-solid.fa-clapperboard.fa-lg
+          | &nbsp;&nbsp;いいね

--- a/app/views/videos/bookmarks.html.slim
+++ b/app/views/videos/bookmarks.html.slim
@@ -1,5 +1,5 @@
 - if current_user
-  = render 'shared/header'
+  = render 'shared/bookmark_header'
 .container
   - if @bookmark_videos.present?
     #video-pagenate


### PR DESCRIPTION
## 概要
これまでいいねページで検索すると動画一覧ページに遷移していたため、いいねしていない動画も検索結果として表示していました。
修正後、いいねした動画のみ検索結果として表示するように設定。
